### PR TITLE
Support union of custom marshmallow types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # marshmallow\_dataclass change log
 
-## v8.6.0 [strateos changes]
+## v8.6.1 [strateos changes]
 
 - Enable Union `_serialize` function to accept custom marshmallow types. 
 - Add custom serialization function to Union class for values with base class: `NodeOuptut`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # marshmallow\_dataclass change log
 
+## v8.6.0 [strateos changes]
+
+- Enable Union `_serialize` function to accept custom marshmallow types. 
+- Add custom serialization function to Union class for values with base class: `NodeOuptut`.
+  ([#1](https://github.com/transcriptic/marshmallow_dataclass/pull/1))
+
+
 ## v8.5.3
 
 - Fix spurious `ValueError` when defining a Union field with explicit default value

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -57,12 +57,13 @@ class Union(fields.Field):
 
     def node_output_serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
         errors = []
+        try:
+            value.__annotations__.keys()
+        except:
+            return "None"
         serialized_outputs = {}
         num_successfully_serialized_outputs = 0
         expected_serialized_output_keys = value.__annotations__.keys()
-        if value is None:
-            return value
-
         for param_key in value.__annotations__.keys():
             param_value = getattr(value, param_key)
 

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -39,7 +39,9 @@ class Union(fields.Field):
         if value is None:
             return value
         for typ, field in self.union_fields:
-            if typ.__dict__.get('__supertype__') and typ.__dict__.get('_marshmallow_field'):
+            if typ.__dict__.get("__supertype__") and typ.__dict__.get(
+                "_marshmallow_field"
+            ):
                 typ = typ.__supertype__
             try:
                 typeguard.check_type(attr, value, typ)

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -34,29 +34,27 @@ class Union(fields.Field):
 
         self.union_fields = new_union_fields
 
-    # def _serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
-        
-    #     errors = []
-    #     if value is None:
-    #         return value
-    #     for typ, field in self.union_fields:
-    #         if typ.__dict__.get("__supertype__") and typ.__dict__.get(
-    #             "_marshmallow_field"
-    #         ):
-    #             typ = typ.__supertype__
-    #         try:
-    #             typeguard.check_type(attr, value, typ)
-    #             return field._serialize(value, attr, obj, **kwargs)
-    #         except TypeError as e:
-    #             errors.append(e)
-    #     raise TypeError(
-    #         f"Unable to serialize value with any of the fields in the union: {errors}"
-    #     )
-
     def _serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
-        print("value")
-        print(value)
-        asd
+        errors = []
+        if value is None:
+            return value
+        elif value.__class__.__bases__[0].__name__ == "NodeOutput":
+            return self.node_output_serialize(value, attr, obj, **kwargs)
+        for typ, field in self.union_fields:
+            if typ.__dict__.get("__supertype__") and typ.__dict__.get(
+                "_marshmallow_field"
+            ):
+                typ = typ.__supertype__
+            try:
+                typeguard.check_type(attr, value, typ)
+                return field._serialize(value, attr, obj, **kwargs)
+            except TypeError as e:
+                errors.append(e)
+        raise TypeError(
+            f"Unable to serialize value with any of the fields in the union: {errors}"
+        )
+
+    def node_output_serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
         errors = []
         serialized_outputs = {}
         num_successfully_serialized_outputs = 0
@@ -65,45 +63,28 @@ class Union(fields.Field):
             return value
 
         for param_key in value.__annotations__.keys():
-            print("param_key")
-            print(param_key)
-            print(getattr(value, param_key))
             param_value = getattr(value, param_key)
 
-            for typ, field in self.union_fields:                
-                # print("typ")
-                # print(typ)
-                # print("field")
-                # print(field)
-                # print("param_value")
-                # print(param_value)
-                # print(value)
-                # print("value dir")
-                # print((dir(value)))
-                # print("__supertype__")
-                # print((typ.__supertype__))
+            for typ, field in self.union_fields:
                 if typ.__dict__.get("__supertype__") and typ.__dict__.get(
                     "_marshmallow_field"
                 ):
                     typ = typ.__supertype__
-                    print(typ)
                 try:
                     typeguard.check_type(attr, param_value, typ)
-                    serialized_output = field._serialize(param_value, attr, obj, **kwargs)
-                    print("serialized_output")
-                    print(serialized_output)
+                    serialized_output = field._serialize(
+                        param_value, attr, obj, **kwargs
+                    )
                     serialized_outputs[param_key] = serialized_output
                     num_successfully_serialized_outputs += 1
                 except TypeError as e:
                     errors.append(e)
-        print(num_successfully_serialized_outputs)
         if num_successfully_serialized_outputs != num_expected_serialized_outputs:
             raise TypeError(
                 f"Unable to serialize value with any of the fields in the union: {errors}"
             )
         else:
             return serialized_outputs
-
 
     def _deserialize(self, value: Any, attr: Optional[str], data, **kwargs) -> Any:
         errors = []

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -39,6 +39,8 @@ class Union(fields.Field):
         if value is None:
             return value
         for typ, field in self.union_fields:
+            if typ.__dict__.get('__supertype__') and typ.__dict__.get('_marshmallow_field'):
+                typ = typ.__supertype__
             try:
                 typeguard.check_type(attr, value, typ)
                 return field._serialize(value, attr, obj, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "8.6.0"
+VERSION = "8.6.1"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "8.5.3"
+VERSION = "8.6.0"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
@@ -51,7 +51,7 @@ setup(
     ),
     author="Ophir LOJKINE",
     author_email="pere.jobs@gmail.com",
-    url="https://github.com/lovasoa/marshmallow_dataclass",
+    url="https://github.com/transcriptic/marshmallow_dataclass",
     keywords=["marshmallow", "dataclass", "serialization"],
     classifiers=CLASSIFIERS,
     license="MIT",

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -180,3 +180,59 @@ class TestClassSchema(unittest.TestCase):
             )
         with self.assertRaises(marshmallow.exceptions.ValidationError):
             schema.load({"value": None})
+
+    def test_union_with_custom_types(self):
+
+        @dataclass
+        class ClassA:
+            elm_a_1: int
+            elm_a_2: int
+
+
+        class ClassAField(fields.Field):
+            def _serialize(self, value, attr, obj, **kwargs) -> dict:
+                serialized_list = [value.elm_a_1, value.elm_a_2]
+                return serialized_list
+
+
+        class_a_type = marshmallow_dataclass.NewType(
+            "ClassA", ClassA, field=ClassAField
+        )
+
+
+        @dataclass
+        class ClassB:
+            elm_b_1: int
+            elm_b_2: str        
+
+
+        class ClassBField(fields.Field):
+            def _serialize(self, value, attr, obj, **kwargs) -> dict:
+                serialized_list = [value.elm_b_1, value.elm_b_2]
+                return serialized_list
+
+
+        class_b_type = marshmallow_dataclass.NewType(
+            "ClassB", ClassB, field=ClassBField
+        )
+
+
+        @dataclass
+        class Schema(Schema):
+            class_name: str
+            output: marshmallow_dataclass.Union[class_b_type, class_a_type]
+
+
+        MarshmallowSchema = marshmallow_dataclass.class_schema(Schema)
+
+        outputs_to_serialize = Schema("A", ClassA(100, 100))
+        assert MarshmallowSchema().dump(outputs_to_serialize) == {
+            "output": [100, 100],
+            "class_name": "A",
+        }
+
+        outputs_to_serialize = Schema("B", ClassB(100, "test"))
+        assert MarshmallowSchema().dump(outputs_to_serialize) == {
+            "output": [100, "test"],
+            "class_name": "B",
+        }

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union, Dict
 
 import marshmallow
 
-from marshmallow_dataclass import dataclass
+from marshmallow_dataclass import dataclass, NewType, Union, class_schema
 
 
 class TestClassSchema(unittest.TestCase):
@@ -187,12 +187,12 @@ class TestClassSchema(unittest.TestCase):
             elm_a_1: int
             elm_a_2: int
 
-        class ClassAField(fields.Field):
+        class ClassAField(marshmallow.fields.Field):
             def _serialize(self, value, attr, obj, **kwargs) -> dict:
                 serialized_list = [value.elm_a_1, value.elm_a_2]
                 return serialized_list
 
-        class_a_type = marshmallow_dataclass.NewType(
+        class_a_type = NewType(
             "ClassA", ClassA, field=ClassAField
         )
 
@@ -201,21 +201,21 @@ class TestClassSchema(unittest.TestCase):
             elm_b_1: int
             elm_b_2: str
 
-        class ClassBField(fields.Field):
+        class ClassBField(marshmallow.fields.Field):
             def _serialize(self, value, attr, obj, **kwargs) -> dict:
                 serialized_list = [value.elm_b_1, value.elm_b_2]
                 return serialized_list
 
-        class_b_type = marshmallow_dataclass.NewType(
+        class_b_type = NewType(
             "ClassB", ClassB, field=ClassBField
         )
 
         @dataclass
-        class Schema(Schema):
+        class Schema(marshmallow.Schema):
             class_name: str
-            output: marshmallow_dataclass.Union[class_b_type, class_a_type]
+            output: Union[class_b_type, class_a_type]
 
-        MarshmallowSchema = marshmallow_dataclass.class_schema(Schema)
+        MarshmallowSchema = class_schema(Schema)
 
         outputs_to_serialize = Schema("A", ClassA(100, 100))
         assert MarshmallowSchema().dump(outputs_to_serialize) == {

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -182,46 +182,38 @@ class TestClassSchema(unittest.TestCase):
             schema.load({"value": None})
 
     def test_union_with_custom_types(self):
-
         @dataclass
         class ClassA:
             elm_a_1: int
             elm_a_2: int
-
 
         class ClassAField(fields.Field):
             def _serialize(self, value, attr, obj, **kwargs) -> dict:
                 serialized_list = [value.elm_a_1, value.elm_a_2]
                 return serialized_list
 
-
         class_a_type = marshmallow_dataclass.NewType(
             "ClassA", ClassA, field=ClassAField
         )
 
-
         @dataclass
         class ClassB:
             elm_b_1: int
-            elm_b_2: str        
-
+            elm_b_2: str
 
         class ClassBField(fields.Field):
             def _serialize(self, value, attr, obj, **kwargs) -> dict:
                 serialized_list = [value.elm_b_1, value.elm_b_2]
                 return serialized_list
 
-
         class_b_type = marshmallow_dataclass.NewType(
             "ClassB", ClassB, field=ClassBField
         )
-
 
         @dataclass
         class Schema(Schema):
             class_name: str
             output: marshmallow_dataclass.Union[class_b_type, class_a_type]
-
 
         MarshmallowSchema = marshmallow_dataclass.class_schema(Schema)
 


### PR DESCRIPTION
This updates the Union class in marshmallow_dataclasses so that it can accept polymorphic typing of custom marshmallow types as well as the predefined marshmallow types and primitive types.